### PR TITLE
Fixing unaligned loads in cast_from_bytes function

### DIFF
--- a/include/cthash/internal/convert.hpp
+++ b/include/cthash/internal/convert.hpp
@@ -20,10 +20,12 @@ template <std::unsigned_integral T, byte_like Byte> constexpr auto cast_from_byt
 		}
 		(std::make_index_sequence<sizeof(T)>());
 	} else {
+		T t;
+		std::memcpy(&t, in.data(), sizeof(T));
 		if constexpr (std::endian::native == std::endian::little) {
-			return static_cast<T>(internal::byteswap(*std::bit_cast<const T *>(in.data())));
+			return internal::byteswap(t);
 		} else {
-			return static_cast<T>(*std::bit_cast<const T *>(in.data()));
+			return t;
 		}
 	}
 }
@@ -35,10 +37,12 @@ template <std::unsigned_integral T, byte_like Byte> constexpr auto cast_from_le_
 		}
 		(std::make_index_sequence<sizeof(T)>());
 	} else {
+		T t;
+		std::memcpy(&t, in.data(), sizeof(T));
 		if constexpr (std::endian::native == std::endian::big) {
-			return static_cast<T>(internal::byteswap(*std::bit_cast<const T *>(in.data())));
+			return internal::byteswap(t);
 		} else {
-			return static_cast<T>(*std::bit_cast<const T *>(in.data()));
+			return t;
 		}
 	}
 }


### PR DESCRIPTION
When running cthash with address sanitizer, I am getting:
```
include/cthash/sha2/../internal/convert.hpp:24:33: runtime error: load of misaligned address 0x00000068eb0a for type 'const unsigned int', which requires 4 byte alignment
```

This patch should fix that.